### PR TITLE
Remove the dependency on not

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "hast-util-has-property": "^3.0.0",
     "hast-util-to-string": "^3.0.0",
     "hast-util-whitespace": "^3.0.0",
-    "not": "^0.1.0",
     "nth-check": "^2.0.0",
     "property-information": "^6.0.0",
     "space-separated-tokens": "^2.0.0",


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

The `not` dependency is unused.

Closes #8

<!--do not edit: pr-->
